### PR TITLE
make adding new links for people easier

### DIFF
--- a/data/people.conf
+++ b/data/people.conf
@@ -13,37 +13,35 @@ year = 1999
 id  = adam_turoff
 g = Perl User Groups
 
-
 [Elaine Ashton]
 year = 2000
 id   = elaine_ashton
 g = Perl User Groups
-pause = HFB
+link_pause = HFB
 
 [Chris Nandor]
 id   = chris_nandor
 year = 2000
 g = Perl Advocacy
 url = https://pudge.net/
-pause = CNANDOR
-linkedin = chrisnandor
-github = pudge
+link_pause = CNANDOR
+link_linkedin = chrisnandor
+link_github = pudge
 
 [Nat Torkington]
 id   = nat_torkington
 year = 2000
 g = Perl Community
-pause = GNAT
 url = https://nathan.torkington.com/
-linkedin = nathantorkington
-github = njt
+link_pause = GNAT
+link_linkedin = nathantorkington
+link_github = njt
 
 [David H. Adler]
 id   = david_h_adler
 year = 2001
 g    = Perl User Groups
-pause = DHA
-
+link_pause = DHA
 
 [Ask Bj&oslash;rn Hansen]
 year = 2001
@@ -57,7 +55,6 @@ year = 2001
 g    = Perl Advocacy
 # Leon Brocard, Greg McCarroll, and Jonathan Peterson.
 
-
 [Graham Barr]
 id   = graham_barr
 year = 2002
@@ -65,23 +62,22 @@ year = 2002
 [Dr. Tim Maher]
 id   = tim_maher
 year = 2002
-linkedin = tim-maher-bb510037
+link_linkedin = tim-maher-bb510037
 url = https://www.teachmeperl.com/consultix/tim_pro.html
 
 [Tim Vroom]
 id   = tim_vroom
 year = 2002
-pause = VROOM
-linkedin = timvroom
-github = tvroom
+link_pause = VROOM
+link_linkedin = timvroom
+link_github = tvroom
 url = https://www.perlmonks.org/
 
 [Jarkko Hietaniemi]
 id   = jarkko_hietaniemi
 year = 2003
-pause = JHI
-linkedin = jarkkohietaniemi
-
+link_pause = JHI
+link_linkedin = jarkkohietaniemi
 
 [Andreas Koenig]
 id   = andreas_koenig
@@ -92,14 +88,12 @@ url = http://search.cpan.org/~andk/
 id   = robert_spier
 year = 2003
 
-
-
 [Dave Cross]
 id   = dave_cross
 year = 2004
 url  =  http://dave.org.uk/
-linkedin = davorg
-github = davorg
+link_linkedin = davorg
+link_github = davorg
 
 # http://use.perl.org/~davorg/journal/rss
 # "long-form"
@@ -114,7 +108,6 @@ year = 2004
 [Jon Orwant]
 id   = jon_orwant
 year = 2004
-
 
 [Stas Bekman]
 id   = stas_bekman
@@ -145,7 +138,6 @@ feed1 = http://use.perl.org/~petdance/journal/rss
 feed2  = http://theworkinggeek.com/atom.xml
 title2 = Andy Lester the working geek
 
-
 [Jay Hannah]
 id   = jay_hannah
 year = 2006
@@ -166,7 +158,6 @@ year = 2006
 [Randal Schwartz]
 id   = randal_schwartz
 year = 2006
-
 
 [Allison Randal]
 id   = allison_randal
@@ -193,184 +184,178 @@ feed1 = http://use.perl.org/~jarich/journal/rss
 id   = gabor_szabo
 year = 2008
 url = http://www.szabgab.com/
-pause = SZABGAB
-github = szabgab
-linkedin = szabgab
+link_pause = SZABGAB
+link_github = szabgab
+link_linkedin = szabgab
 
 feed1  = http://szabgab.com/blog/szabgab.rss
 title1 = Gábor Szabó
 
-
 [Tatsuhiko Miyagawa]
 id   = tatsuhiko_miyagawa
 year = 2008
-github = miyagawa
-linkedin = miyagawa
+link_github = miyagawa
+link_linkedin = miyagawa
 
 [Tim Bunce]
 year = 2009
 id = tim_bunce
-pause = TIMB
-github = timbunce
-linkedin = timbunce
+link_pause = TIMB
+link_github = timbunce
+link_linkedin = timbunce
 
 [Philippe Bruhat]
 year = 2009
 id = philippe_bruhat
-pause = BOOK
-github =  book
-linkedin = philippebruhat
+link_pause = BOOK
+link_github =  book
+link_linkedin = philippebruhat
 
 [Michael Schwern]
 year = 2009
 id = michael_schwern
-pause = MSCHWERN
-github = schwern
-linkedin = schwern
+link_pause = MSCHWERN
+link_github = schwern
+link_linkedin = schwern
 
 [José Castro]
 year = 2010
 id = jose_castro
 # (cog)
 g = Perl User Groups
-pause = COG
-github = cog
-linkedin = josecastro
+link_pause = COG
+link_github = cog
+link_linkedin = josecastro
 
 [Paul Fenwick]
 year = 2010
 id = paul_fenwick
 g = Perl Advocacy
-pause = PJF
-github = pjf
-linkedin = pfenwick
+link_pause = PJF
+link_github = pjf
+link_linkedin = pfenwick
 
 [Barbie]
 year = 2010
 id = barbie
 g = Perl Community
-pause = BARBIE
-github = barbie
-linkedin = barbie
+link_pause = BARBIE
+link_github = barbie
+link_linkedin = barbie
 
 [Leo Lapworth]
 year = 2011
 id = leo_lapworth
 g = Perl Community
-pause = LLAP
-github = ranguard
-linkedin = leolapworth
+link_pause = LLAP
+link_github = ranguard
+link_linkedin = leolapworth
 
 [Daisuke Maki]
 year = 2011
 id = daisuke_maki
 g = Perl user groups
-pause = DMAKI
-github = Maki-Daisuke
-linkedin = lestrrat
+link_pause = DMAKI
+link_github = Maki-Daisuke
+link_linkedin = lestrrat
 
 [Andrew Shitov]
 year = 2011
 id = andrew_shitov
 g = Perl conferences
-pause = ANDY
-github = ash
-linkedin = andrewshitov
+link_pause = ANDY
+link_github = ash
+link_linkedin = andrewshitov
 
 [Renee Bäcker]
 year = 2012
 id = renee_baecker
 g = Perl Community
-pause = RENEEB
-github = reneeb
-linkedin = renee-b-545998161
+link_pause = RENEEB
+link_github = reneeb
+link_linkedin = renee-b-545998161
 
 [Jim Keenan]
 year = 2012
 id = jim_keenan
 g = Perl User Groups
-pause = JKEENAN
-github = jkeenan
-linkedin = james-e-keenan-630b362
+link_pause = JKEENAN
+link_github = jkeenan
+link_linkedin = james-e-keenan-630b362
 
 [Breno G. de Oliveira]
 # garu
 year = 2012
 id = breno_oliveira
 g = Perl Conferences
-pause = GARU
-github = garu
-linkedin = breno
-
+link_pause = GARU
+link_github = garu
+link_linkedin = breno
 
 [Thiago Rondon]
 year  = 2013
-pause = TBR
+link_pause = TBR
 g = Perl community
 id = thiago_rondon
-github = thiagorondon
-linkedin = thiagorondon
+link_github = thiagorondon
+link_linkedin = thiagorondon
 
 [Fred Moyer]
 year  = 2013
-pause = PHRED
+link_pause = PHRED
 g = Perl user groups
 id = fred_moyer
-github = redhotpenguin
-linkedin = redhotpenguin
-
+link_github = redhotpenguin
+link_linkedin = redhotpenguin
 
 [Wendy and Liz]
 year  = 2013
-pause = ELIZABETH
-g = Perl advocacy
 id = wendy_and_liz
-
+g = Perl advocacy
+link_pause = ELIZABETH
 
 [Amalia Pomian]
 year = 2014
-pause =
+link_pause =
 g = Perl Community
 id = amalia_pomain
-linkedin = amalia-aida-pomian
+link_linkedin = amalia-aida-pomian
 
 [VM Brasseur]
 year = 2014
-pause =
+link_pause =
 g = Perl User Groups
 id = vm_brasseur
-github = vmbrasseur
-linkedin = vmbrasseur
+link_github = vmbrasseur
+link_linkedin = vmbrasseur
 
 [Neil Bowers]
 year = 2014
-pause = NEILB
+link_pause = NEILB
 g = Perl Advocacy
 id = neil_bowers
-github = neilb
-linkedin = neil-bowers-567a40
+link_github = neilb
+link_linkedin = neil-bowers-567a40
 
 [Chris Prather]
 year  = 2015
-pause = PERIGRIN
+link_pause = PERIGRIN
 g = Perl User Groups
 id = chris_prather
-github = perigrin
-linkedin = perigrin
-
+link_github = perigrin
+link_linkedin = perigrin
 
 [Sawyer X]
 year  = 2015
-pause = SAWYERX
+link_pause = SAWYERX
 g = Perl Advocacy
 id = sawyer_x
-github = xsawyerx
-linkedin = sawyer-x-040507214
-
+link_github = xsawyerx
+link_linkedin = sawyer-x-040507214
 
 [Steffen Müller]
 year  = 2015
-pause = TSEE
+link_pause = TSEE
 g = Perl Community
 id = steffen_muller
 
@@ -381,13 +366,13 @@ id = karen_pauley
 
 [David Golden]
 year  = 2016
-pause = DAGOLDEN
+link_pause = DAGOLDEN
 g = Perl User Groups
 id = david_golden
 
 [Thomas Klausner]
 year  = 2016
-pause = DOMM
+link_pause = DOMM
 g = Perl Community
 id = thomas_klausner
 
@@ -398,7 +383,7 @@ g = Perl Community
 
 [Laurent Boivin]
 id = laurent_boivin
-pause = ELBEHO
+link_pause = ELBEHO
 year  = 2017
 g = Perl User Groups
 
@@ -411,8 +396,8 @@ g = Perl Advocacy
 id = todd_rinaldo
 year  = 2018
 g = Perl Community
-github = toddr
-linkedin = toddrinaldo
+link_github = toddr
+link_linkedin = toddrinaldo
 
 [David Farrell]
 id = david_farrell
@@ -428,5 +413,5 @@ g = Perl User Groups
 id = mohammad_sajid_anwar
 year = 2022
 g = Perl
-github = manwar
-linkedin = mohammadanwar
+link_github = manwar
+link_linkedin = mohammadanwar

--- a/script/static.pl
+++ b/script/static.pl
@@ -11,6 +11,13 @@ use POSIX qw( ceil );
 
 sub say { print @_, "\n" };
 
+my %URL_Constructors = (
+    pause       => sub { {name => 'CPAN',     url => 'https://metacpan.org/author/'.$_[0]} },
+    linkedin    => sub { {name => 'Linkedin', url => 'https://linkedin.com/in/'.$_[0]} },
+    github      => sub { {name => 'Github',   url => 'https://github.com/'.$_[0]} },
+    UNKNOWN     => sub { {name => 'Website',  url => $_} },
+);
+
 my $dir = 'docs';
 if (@ARGV) {
     $dir = shift @ARGV;
@@ -79,6 +86,14 @@ for my $row_num (0 .. $num_rows-1) {
 # -- individual people pages --
 for my $person (keys %$conf) {
 	say "processing '$person'\n";
+
+	my @links = map {
+              s/^link_//;
+              ($URL_Constructors{$_} || $URL_Constructors{UNKNOWN})->($conf->{$person}{'link_'.$_})
+            }
+            grep { /^link_/ } 
+            keys %{$conf->{$person}};
+
 	my %params = (
 		TIME  => $time,
 		TITLE => $person.' - Perl White Camel Awards',
@@ -86,9 +101,7 @@ for my $person (keys %$conf) {
 		YEAR  => $conf->{$person}{year},
 		NAME  => $person,
 		BLOB  => $blob{$person},
-        PAUSE => $conf->{$person}{pause},
-		GITHUB  => $conf->{$person}{github},
-		LINKEDIN  => $conf->{$person}{linkedin},
+		LINKS => \@links,
     );
 	if ($blob{$person} eq '') {
 		warn "person '$person' has no blob";
@@ -132,4 +145,3 @@ sub read_file {
 	local $/ = undef;
 	return <$fh>;
 }
-

--- a/templates/person.tmpl
+++ b/templates/person.tmpl
@@ -12,17 +12,11 @@
       <p>Award received in <TMPL_VAR YEAR>.</p>
       <p><TMPL_VAR BLOB></p>
 
-      <TMPL_IF PAUSE>
-         <a href="https://metacpan.org/author/<TMPL_VAR PAUSE>">CPAN</a>
-      </TMPL_IF>
-
-       <TMPL_IF GITHUB>
-         <a href="https://github.com/<TMPL_VAR GITHUB>">GitHub</a>
-      </TMPL_IF>
-
-      <TMPL_IF LINKEDIN>
-         <a href="https://linkedin.com/in/<TMPL_VAR LINKEDIN>">LinkedIn</a>
-      </TMPL_IF>
+      <p>
+      <TMPL_LOOP NAME=LINKS>
+         <span>&#x1F517; <a href="<TMPL_VAR NAME=URL>"><TMPL_VAR NAME=NAME></a></span>
+      </TMPL_LOOP>
+      </p>
 
    </div>
   </div>


### PR DESCRIPTION
With this change, we can add new links for people in format `link_SERVICE`, without modifying template (now it loops over all links).

I guess, a future improvement could be to handle config values like `link_01 = Personal Website|http://person.me`, and, again, this will not require template update.